### PR TITLE
Return ZK ctime with the log entry.

### DIFF
--- a/src/onyx/log/zookeeper.clj
+++ b/src/onyx/log/zookeeper.clj
@@ -93,11 +93,7 @@
         bytes (serialize data)]
     (zk/create conn node :data bytes :persistent? true :sequential? true)))
 
-(defmethod extensions/read-log-entry ZooKeeper
-  [{:keys [conn opts prefix] :as log} position]
-  (let [node (str (log-path prefix) "/entry-" (pad-sequential-id position))
-        content (deserialize (:data (zk/data conn node)))]
-    (assoc content :message-id position)))
+(defmethod extensions/read-log-entry ZooKeeper                                                                                           [{:keys [conn opts prefix] :as log} position]                                                                                          (let [node (str (log-path prefix) "/entry-" (pad-sequential-id position))                                                                    data (zk/data conn node)                                                                                                               content (deserialize (:data data))]                                                                                                (assoc content :message-id position :created-at (:ctime (:stat data)))))
 
 (defmethod extensions/register-pulse ZooKeeper
   [{:keys [conn opts prefix] :as log} id]

--- a/src/onyx/log/zookeeper.clj
+++ b/src/onyx/log/zookeeper.clj
@@ -93,7 +93,12 @@
         bytes (serialize data)]
     (zk/create conn node :data bytes :persistent? true :sequential? true)))
 
-(defmethod extensions/read-log-entry ZooKeeper                                                                                           [{:keys [conn opts prefix] :as log} position]                                                                                          (let [node (str (log-path prefix) "/entry-" (pad-sequential-id position))                                                                    data (zk/data conn node)                                                                                                               content (deserialize (:data data))]                                                                                                (assoc content :message-id position :created-at (:ctime (:stat data)))))
+(defmethod extensions/read-log-entry ZooKeeper
+  [{:keys [conn opts prefix] :as log} position]
+  (let [node (str (log-path prefix) "/entry-" (pad-sequential-id position))
+        data (zk/data conn node)
+        content (deserialize (:data data))]
+    (assoc content :message-id position :created-at (:ctime (:stat data)))))
 
 (defmethod extensions/register-pulse ZooKeeper
   [{:keys [conn opts prefix] :as log} id]


### PR DESCRIPTION
I think it'd be good to have the zookeeper ctime with the returned log entry. With this information we would know what the difference it time was between a job being submitted and being killed, tasks finishing, etc. This is especially useful info for a dashboard or for monitoring. If there's a better way to achieve just let me know!

Cheers