### PR TITLE
Change timbre configuration to log to standard out by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,10 @@ This project is authored by [Michael Drogalis](https://twitter.com/MichaelDrogal
 Copyright © 2015 Michael Drogalis
 
 Distributed under the Eclipse Public License, the same as Clojure.
+
+### Profiler
+
+YourKit supports open source projects with its full-featured Java Profiler.
+YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a>
+and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>,
+innovative and intelligent tools for profiling Java and .NET applications.

--- a/src/onyx/logging_configuration.clj
+++ b/src/onyx/logging_configuration.clj
@@ -14,13 +14,13 @@
           [:appenders :rotor]
           {:min-level :info
            :enabled? true
-           :async? false 
+           :async? false
            :max-message-per-msecs nil
            :fn rotor/appender-fn})
         (timbre/set-config!
           [:shared-appender-config :rotor]
           {:path file :max-size (* 512 10240) :backlog 5})
-        (timbre/set-config! [:appenders :standard-out :enabled?] false)
+        (timbre/set-config! [:appenders :standard-out :enabled?] true)
         (timbre/set-config! [:appenders :spit :enabled?] false)))
 
     (info "Starting Logging Configuration")

--- a/src/onyx/logging_configuration.clj
+++ b/src/onyx/logging_configuration.clj
@@ -20,7 +20,9 @@
         (timbre/set-config!
           [:shared-appender-config :rotor]
           {:path file :max-size (* 512 10240) :backlog 5})
-        (timbre/set-config! [:appenders :standard-out :enabled?] true)
+        (timbre/set-config! [:appenders :standard-out]
+                            {:min-level :error
+                             :enabled? true})
         (timbre/set-config! [:appenders :spit :enabled?] false)))
 
     (info "Starting Logging Configuration")


### PR DESCRIPTION
I enabled the :standard-out appender in the timbre configuration