### PR TITLE
Fixes custom config passing to logging_configuration

### DIFF
--- a/src/onyx/logging_configuration.clj
+++ b/src/onyx/logging_configuration.clj
@@ -8,7 +8,7 @@
 
   (start [component]
     (if config
-      (timbre/set-config! [] config)
+      (reset! timbre/config config)
       (do
         (timbre/set-config!
           [:appenders :rotor]


### PR DESCRIPTION
Timbre set-config! uses assoc-in to update the taoensso.timbre/config logging configuration. As is, this causes the timbre config map to merge an extra key {nil <new-config>} effectively negating the configuration changes. You can get around this by passing in nil merging the key {nil nil} to have onyx ignore logging configuration but this does not seem like the intended behavior.