### PR TITLE
function params could not reference injected lifecycle resources

### DIFF
--- a/src/onyx/peer/task_lifecycle.clj
+++ b/src/onyx/peer/task_lifecycle.clj
@@ -306,7 +306,9 @@
                            :onyx.core/state (atom {})}
 
             ex-f (fn [e] (handle-exception e restart-ch outbox-ch job-id))
-            pipeline-data (merge pipeline-data (l-ext/inject-lifecycle-resources* pipeline-data))]
+            pipeline-data (merge pipeline-data (l-ext/inject-lifecycle-resources* pipeline-data))
+            calling-params (resolve-calling-params (merge pipeline-data catalog-entry) opts)
+            pipeline-data (if calling-params (assoc pipeline-data :onyx.core/params calling-params) pipeline-data)]
 
         (while (and (first (alts!! [kill-ch] :default true))
                     (not (:onyx.core/start-lifecycle? (munge-start-lifecycle pipeline-data))))


### PR DESCRIPTION
function params could not reference injected lifecycle resources which is a bit prohibitive if you want to, for instance, send the async channel along into the function call..